### PR TITLE
2 Random fixes

### DIFF
--- a/terminal.py
+++ b/terminal.py
@@ -387,15 +387,16 @@ class TerminalActivity(activity.Activity):
             for l in tab_state['scrollback']:
                 vt.feed(str(l) + '\r\n')
 
+        shell_cmd = os.environ.get('SHELL') or '/bin/bash'
         if hasattr(vt, 'fork_command_full'):
             sucess_, box.pid = vt.fork_command_full(
                 Vte.PtyFlags.DEFAULT, os.environ["HOME"],
-                ["/bin/bash"], [], GLib.SpawnFlags. DO_NOT_REAP_CHILD,
+                [shell_cmd], [], GLib.SpawnFlags. DO_NOT_REAP_CHILD,
                 None, None)
         else:
             sucess_, box.pid = vt.spawn_sync(
                 Vte.PtyFlags.DEFAULT, os.environ["HOME"],
-                ["/bin/bash"], [], GLib.SpawnFlags. DO_NOT_REAP_CHILD,
+                [shell_cmd], [], GLib.SpawnFlags. DO_NOT_REAP_CHILD,
                 None, None)
 
         self._notebook.props.page = index

--- a/terminal.py
+++ b/terminal.py
@@ -510,12 +510,17 @@ class TerminalActivity(activity.Activity):
 
             scrollback_lines = text.split('\n')
 
-            # Note- this currently gets the child's initial environment
-            # rather than the current environment, making it not very useful.
-            environment = open('/proc/%d/environ' %
-                               page.pid, 'r').read().split('\0')
+            environ_file = '/proc/%d/environ' % page.pid
+            if os.path.isfile(environ_file):
+                # Note- this currently gets the child's initial environment
+                # rather than the current environment, making it not very useful.
+                environment = open(environ_file, 'r').read().split('\0')
 
-            cwd = os.readlink('/proc/%d/cwd' % page.pid)
+                cwd = os.readlink('/proc/%d/cwd' % page.pid)
+            else:
+                # terminal killed by the user
+                environment = []
+                cwd = '~'
 
             font_desc = page.vt.get_font()
 


### PR DESCRIPTION
commit 2983f6a605e67bab599c454cba2ab6d60e69dd1b
Author: Sam Parkinson <sam@sam.today>
Date:   Wed May 11 15:29:47 2016 +1000

    Don't cause keep failure if user Ctrl-D closes their shell
    
    When the shell process quits, there is not environ file that we
    can read.  So, we can simply disregard that and save no envars.

commit 9ca3aa1ce4e98c022aa15483ef842698ab5313da
Author: Sam Parkinson <sam@sam.today>
Date:   Wed May 11 15:27:57 2016 +1000

    Use the user's shell, rather than always BASH
    
    Bash is a pretty average shell.  Some kids (or older people alike)
    might like a pretty looking shell like fish.  We can read the
    user's current shell from the SHELL envar, which is set through the
    "chsh" command.  Eventually, we could provide a GUI for setting that,
    but that is for the future.
