### PR TITLE
Fix: #23 Help button fixed and improved

### DIFF
--- a/helpbutton.py
+++ b/helpbutton.py
@@ -37,6 +37,7 @@ class HelpButton(Gtk.ToolItem):
     def __init__(self, **kwargs):
         GObject.GObject.__init__(self)
 
+        self.help_on = False
         help_button = ToolButton('toolbar-help')
         help_button.set_tooltip(_('Help'))
         self.add(help_button)
@@ -65,7 +66,12 @@ class HelpButton(Gtk.ToolItem):
         help_button.connect('clicked', self.__help_button_clicked_cb)
 
     def __help_button_clicked_cb(self, button):
-        self._palette.popup(immediate=True)
+        if self.help_on:
+            self._palette.popdown(immediate=True)
+            self.help_on = False
+        else:
+            self._palette.popup(immediate=True)
+            self.help_on = True
 
     def add_section(self, section_text):
         hbox = Gtk.Box()

--- a/helpbutton.py
+++ b/helpbutton.py
@@ -65,7 +65,7 @@ class HelpButton(Gtk.ToolItem):
         help_button.connect('clicked', self.__help_button_clicked_cb)
 
     def __help_button_clicked_cb(self, button):
-        self._palette.popup(immediate=True, state=1)
+        self._palette.popup(immediate=True)
 
     def add_section(self, section_text):
         hbox = Gtk.Box()


### PR DESCRIPTION
**Fixed in this PR:** Help Button not working

**Changes made:**
 1. Help Button now working
 2. In 107e3d6, added help popup toggling.

**Approaches tried for 2:**
 1. Changing `immediate` as `False`, but that caused re-popup of help, via mouse hover, even after popdown caused by a mouse click
 2. `PaletteWindow` methods/states weren't useful in this regard

**Tested on:**
Ubuntu 16.04, rdesktop, Sugar 0.112