### PR TITLE
Add URL support and Custom Theme for Terminal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@
 .*.sw?
 locale/
 MANIFEST
+.idea
+.vscode
 dist/

--- a/icons/browse-follow-link.svg
+++ b/icons/browse-follow-link.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+  <!ENTITY fill_color "#FFFFFF">
+  <!ENTITY stroke_color "#010101">
+]>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="55.125"
+   height="55"
+   viewBox="0 0 55.125 55"
+   id="browse-follow-link"
+   xml:space="preserve">
+<g
+   transform="translate(-0.37116731,15.564534)"
+   id="g3868"><line
+     style="fill:none;stroke:&fill_color;;stroke-width:5.25;stroke-linecap:round;stroke-linejoin:round"
+     x1="40.705868"
+     x2="15.161467"
+     y1="11.934416"
+     y2="11.934416"
+     id="line15" /><polyline
+     transform="matrix(2.1,0,0,2.1,-18.234832,-2.7088836)"
+     style="fill:none;stroke:&fill_color;;stroke-width:2.5;stroke-linecap:round;stroke-linejoin:round"
+     points="     21.983,1.843 28.067,6.973 21.983,12.104    "
+     id="polyline17" /></g></svg>

--- a/palette.py
+++ b/palette.py
@@ -1,0 +1,135 @@
+import logging
+import tempfile
+
+from gi.repository import Gdk
+from gi.repository import GLib, Gtk, SugarGestures
+from sugar3 import profile
+from sugar3.graphics.palette import Palette
+from sugar3.graphics.palettemenu import PaletteMenuItem, PaletteMenuItemSeparator
+from gettext import gettext as _
+
+from sugar3.graphics.palettewindow import Invoker
+
+
+class ContentInvoker(Invoker):
+    def __init__(self, parent, link):
+        Invoker.__init__(self)
+        self._position_hint = self.AT_CURSOR
+        self.parent = parent
+        self._link = link
+
+        self.parent.connect('realize', self.__term_realize_cb)
+        self.palette = TerminalPalette(self.parent, self._link)
+        self.notify_right_click()
+
+    def __term_realize_cb(self, browser):
+        x11_window = browser.get_window()
+        x11_window.set_events(x11_window.get_events() |
+                              Gdk.EventMask.POINTER_MOTION_MASK |
+                              Gdk.EventMask.TOUCH_MASK)
+
+        lp = SugarGestures.LongPressController()
+        lp.connect('pressed', self.__long_pressed_cb)
+        lp.attach(browser, SugarGestures.EventControllerFlags.NONE)
+
+    def __long_pressed_cb(self, controller, x, y):
+        # We can't force a context menu, but we can fake a right mouse click
+        event = Gdk.Event()
+        event.type = Gdk.EventType.BUTTON_PRESS
+
+        b = event.button
+        b.type = Gdk.EventType.BUTTON_PRESS
+        b.window = self.activity.get_window()
+        b.time = Gtk.get_current_event_time()
+        b.button = 3  # Right
+        b.x = x
+        b.y = y
+        b.x_root, b.y_root = self.activity.get_window().get_root_coords(x, y)
+
+        Gtk.main_do_event(event)
+        return True
+
+    def get_default_position(self):
+        return self.AT_CURSOR
+
+    def get_rect(self):
+        allocation = self.activity.get_allocation()
+        window = self.activity.get_window()
+        if window is not None:
+            res, x, y = window.get_origin()
+        else:
+            logging.warning(
+                "Trying to position palette with invoker that's not realized.")
+            x = 0
+            y = 0
+
+        x += allocation.x
+        y += allocation.y
+
+        width = allocation.width
+        height = allocation.height
+
+        rect = Gdk.Rectangle()
+        rect.x = x
+        rect.y = y
+        rect.width = width
+        rect.height = height
+        return rect
+
+    def get_toplevel(self):
+        return None
+
+
+class TerminalPalette(Palette):
+    def __init__(self, parent, link=False):
+        Palette.__init__(self)
+        self.parent = parent
+        self._link = link
+        self.create()
+        self.popup()
+
+    def create(self):
+
+        if self._link is not None:
+            self.props.primary_text = GLib.markup_escape_text(self._link)
+        else:
+            self.props.primary_text = GLib.markup_escape_text(_('Terminal'))
+        menu_box = Gtk.VBox()
+        self.set_content(menu_box)
+        menu_box.show()
+        self._content.set_border_width(1)
+
+        if self._link:
+
+            menu_item = PaletteMenuItem(_('Follow link'), 'browse-follow-link')
+            menu_item.connect('activate', self.__follow_activate_cb)
+            menu_box.pack_start(menu_item, False, False, 0)
+            menu_item.show()
+
+            menu_item = PaletteMenuItem(_('Copy link'), 'edit-copy')
+            menu_item.icon.props.xo_color = profile.get_color()
+            menu_item.connect('activate', self.__copy_cb)
+            menu_box.pack_start(menu_item, False, False, 0)
+            menu_item.show()
+
+        if not self._link:
+            menu_item = PaletteMenuItem(_('Copy text'), 'edit-copy')
+            menu_item.icon.props.xo_color = profile.get_color()
+            menu_item.connect('activate', self.__copy_cb)
+            menu_box.pack_start(menu_item, False, False, 0)
+            menu_item.show()
+
+        menu_item = PaletteMenuItem(_('Paste text'), 'edit-paste')
+        menu_item.icon.props.xo_color = profile.get_color()
+        menu_item.connect('activate', self.__paste_cb)
+        menu_box.pack_start(menu_item, False, False, 0)
+        menu_item.show()
+
+    def __follow_activate_cb(self, button):
+        self.parent.browse_link_under_cursor()
+
+    def __copy_cb(self, button):
+        self.parent.copy_clipboard()
+
+    def __paste_cb(self, button):
+        self.parent.paste_clipboard()

--- a/palette.py
+++ b/palette.py
@@ -129,7 +129,7 @@ class TerminalPalette(Palette):
         self.parent.browse_link_under_cursor()
 
     def __copy_cb(self, button):
-        self.parent.copy_clipboard()
+        self.parent.copy_clipboard(None, self._link)
 
     def __paste_cb(self, button):
         self.parent.paste_clipboard()

--- a/sugarterm.py
+++ b/sugarterm.py
@@ -87,7 +87,8 @@ try:
         at_exit_call(libutempter.utempter_remove_added_record)
 except Exception as e:
     libutempter = None
-    sys.stderr.write("[WARN] ===================================================================\n")
+    sys.stderr.write(
+        "[WARN] ===================================================================\n")
     sys.stderr.write("[WARN] Unable to load the library libutempter !\n")
     sys.stderr.write(
         "[WARN] Some feature might not work:\n"
@@ -118,6 +119,7 @@ class SugarTerminal(Vte.Terminal):
     """
     Just a vte.Terminal with some properties already set.
     """
+
     def __init__(self, activity):
         super(SugarTerminal, self).__init__()
         self.activity = activity
@@ -126,8 +128,10 @@ class SugarTerminal(Vte.Terminal):
         self.add_matches()
         self.handler_ids = []
         self.read_config()
-        self.handler_ids.append(self.connect('button-press-event', self.button_press))
-        self.connect('child-exited', self.on_child_exited)  # Call on_child_exited, don't remove it
+        self.handler_ids.append(self.connect(
+            'button-press-event', self.button_press))
+        # Call on_child_exited, don't remove it
+        self.connect('child-exited', self.on_child_exited)
         self.matched_value = ''
         self.font_scale_index = 0
         self._pid = None
@@ -251,10 +255,10 @@ class SugarTerminal(Vte.Terminal):
             VTE_REGEX_FLAGS = 0x40080400
             for expr in TERMINAL_MATCH_EXPRS:
                 tag = self.match_add_regex(
-                    Vte.Regex.new_for_match(expr, len(expr), VTE_REGEX_FLAGS), 0
+                    Vte.Regex.new_for_match(
+                        expr, len(expr), VTE_REGEX_FLAGS), 0
                 )
                 self.match_set_cursor_type(tag, Gdk.CursorType.HAND2)
-
 
         except (GLib.Error, AttributeError) as e:  # pylint: disable=catching-non-exception
             try:
@@ -262,16 +266,17 @@ class SugarTerminal(Vte.Terminal):
                 if (Vte.MAJOR_VERSION, Vte.MINOR_VERSION) >= (0, 44):
                     compile_flag = GLib.RegexCompileFlags.MULTILINE
                 for expr in TERMINAL_MATCH_EXPRS:
-                    tag = self.match_add_gregex(GLib.Regex.new(expr, compile_flag, 0), 0)
+                    tag = self.match_add_gregex(
+                        GLib.Regex.new(expr, compile_flag, 0), 0)
                     self.match_set_cursor_type(tag, Gdk.CursorType.HAND2)
-
 
             except GLib.Error as e:  # pylint: disable=catching-non-exception
                 log.error(
                     "ERROR: PCRE2 does not seems to be enabled on your system. "
                     "Quick Edit and other Ctrl+click features are disabled. "
                     "Please update your VTE package or contact your distribution to ask "
-                    "to enable regular expression support in VTE. Exception: '%s'", str(e)
+                    "to enable regular expression support in VTE. Exception: '%s'", str(
+                        e)
                 )
 
     def get_current_directory(self):
@@ -343,7 +348,8 @@ class SugarTerminal(Vte.Terminal):
         try:
             if pt.exists():
                 lineno = find_lineno(text, pt, lineno, py_func)
-                log.info("File exists: %r, line=%r", pt.absolute().as_posix(), lineno)
+                log.info("File exists: %r, line=%r",
+                         pt.absolute().as_posix(), lineno)
                 return (pt, lineno, colno)
             log.debug("No file found matching: %r", text)
             cwd = self.get_current_directory()
@@ -351,7 +357,8 @@ class SugarTerminal(Vte.Terminal):
             log.debug("checking file existance: %r", pt)
             if pt.exists():
                 lineno = find_lineno(text, pt, lineno, py_func)
-                log.info("File exists: %r, line=%r", pt.absolute().as_posix(), lineno)
+                log.info("File exists: %r, line=%r",
+                         pt.absolute().as_posix(), lineno)
                 return (pt, lineno, colno)
             log.debug("file does not exist: %s", str(pt))
         except OSError:
@@ -368,7 +375,8 @@ class SugarTerminal(Vte.Terminal):
             matched_string = self.match_check_event(event)
         else:
             matched_string = self.match_check(
-                int(event.x / self.get_char_width()), int(event.y / self.get_char_height())
+                int(event.x / self.get_char_width()
+                    ), int(event.y / self.get_char_height())
             )
 
         self.found_link = None
@@ -401,7 +409,6 @@ class SugarTerminal(Vte.Terminal):
             text = data.get_text()
             if text:
                 self.feed_child(text)
-
 
     def _on_ctrl_click_matcher(self, matched_string):
         value, tag = matched_string
@@ -486,14 +493,15 @@ class SugarTerminal(Vte.Terminal):
 
     def set_color_bold(self, font_color, *args, **kwargs):
         real_fgcolor = self.custom_fgcolor if self.custom_fgcolor else font_color
-        super(SugarTerminal, self).set_color_bold(real_fgcolor, *args, **kwargs)
+        super(SugarTerminal, self).set_color_bold(
+            real_fgcolor, *args, **kwargs)
 
     def set_term_colors(self, custom_colors):
         fg_color = custom_colors['fg_color']
         bg_color = custom_colors['bg_color']
         try:
             self.set_colors(Gdk.color_parse(fg_color),
-                          Gdk.color_parse(bg_color), [])
+                            Gdk.color_parse(bg_color), [])
         except TypeError:
             # Vte 0.38 requires the colors set as a different type
             # in Fedora 21 we get a exception
@@ -529,14 +537,16 @@ class SugarTerminal(Vte.Terminal):
 
         palette = colors_dict.get('palette', None)
         if isinstance(palette, list):
-            self.custom_palette = [self._color_from_list(col) for col in palette]
+            self.custom_palette = [
+                self._color_from_list(col) for col in palette]
         else:
             self.custom_palette = None
 
     def browse_link_under_cursor(self):
         if not self.found_link:
             return
-        path = os.path.join(self.activity.get_activity_root(), 'instance', '%i' % time.time())
+        path = os.path.join(self.activity.get_activity_root(),
+                            'instance', '%i' % time.time())
         self.create_journal_entry(path, self.found_link)
 
     def create_journal_entry(self, path, URL):

--- a/sugarterm.py
+++ b/sugarterm.py
@@ -559,7 +559,7 @@ class SugarTerminal(Vte.Terminal):
         journal_entry.metadata['keep'] = '0'
         journal_entry.metadata['mime_type'] = 'text/uri-list'
         journal_entry.metadata['icon-color'] = profile.get_color().to_string()
-        journal_entry.metadata['description'] = "This is the URL opening of " + URL
+        journal_entry.metadata['description'] = "Opening {} from the Terminal".format(URL)
         journal_entry.file_path = path
         datastore.write(journal_entry)
         self._object_id = journal_entry.object_id

--- a/sugarterm.py
+++ b/sugarterm.py
@@ -48,6 +48,7 @@ import gi
 from sugar3 import profile, env
 from sugar3.activity.activity import launch_bundle
 from sugar3.datastore import datastore
+from sugar3.graphics.palette import Palette
 
 gi.require_version('Gtk', '3.0')
 gi.require_version('Vte', '2.91')  # vte-0.38
@@ -144,8 +145,24 @@ class SugarTerminal(Vte.Terminal):
         self.custom_bgcolor = None
         self.custom_fgcolor = None
         self.custom_palette = None
-
+        self._create_menu()
         self.setup_drag_and_drop()
+
+    def _create_menu(self):
+        self.menu = Gtk.Menu.new()
+        self.menu_copy = Gtk.MenuItem("Copy Text")
+        self.menu.append(self.menu_copy)
+        self.menu_paste = Gtk.MenuItem("Paste Text")
+        self.menu.append(self.menu_paste)
+        self.menu_copy_link = Gtk.MenuItem("Copy Link")
+        self.menu.append(self.menu_copy_link)
+        self.menu_open_link = Gtk.MenuItem("Open Link in Browser")
+        self.menu.append(self.menu_open_link)
+        # connect menu items
+        self.menu_copy.connect_object("activate", self.copy_clipboard, None)
+        self.menu_paste.connect_object("activate", self.paste_clipboard, None)
+        self.menu_copy_link.connect_object("activate", self.copy_clipboard, None)
+        self.menu_open_link.connect_object("activate", self.copy_clipboard, None)
 
     def configure_terminal(self):
         blink = self._get_conf(self.conf, 'cursor_blink', False)
@@ -237,11 +254,13 @@ class SugarTerminal(Vte.Terminal):
             command += "\n"
         self.feed_child(command)
 
-    def copy_clipboard(self):
+    def copy_clipboard(self, widget=None):
         if self.get_has_selection():
             super(SugarTerminal, self).copy_clipboard()
-        elif self.matched_value:
-            log.warning('Not Implemented Sugar')
+
+    def paste_clipboard(self, widget=None):
+        if self.get_has_selection():
+            super(SugarTerminal, self).paste_clipboard()
 
     def add_matches(self):
         """Adds all regular expressions declared in
@@ -394,6 +413,19 @@ class SugarTerminal(Vte.Terminal):
             self.found_link = self.handleTerminalMatch(matched_string)
             self.matched_value = matched_string[0]
 
+        if event.type == Gdk.EventType.BUTTON_PRESS and event.button == 3:
+            if self.found_link:
+                self.menu_copy_link.show()
+                self.menu_open_link.show()
+                self.menu_copy.hide()
+                self.menu_paste.hide()
+            else:
+                self.menu_copy_link.hide()
+                self.menu_open_link.hide()
+                self.menu_copy.show()
+                self.menu_paste.show()
+            self.menu.popup(None, None, None, None, event.button, event.time)
+
     def on_child_exited(self, target, status, *user_data):
         if libutempter is not None:
             if self.get_pty() is not None:
@@ -542,6 +574,7 @@ class SugarTerminal(Vte.Terminal):
         else:
             self.custom_palette = None
 
+
     def browse_link_under_cursor(self):
         if not self.found_link:
             return
@@ -564,3 +597,4 @@ class SugarTerminal(Vte.Terminal):
         datastore.write(journal_entry)
         self._object_id = journal_entry.object_id
         launch_bundle(object_id=self._object_id)
+

--- a/sugarterm.py
+++ b/sugarterm.py
@@ -150,13 +150,13 @@ class SugarTerminal(Vte.Terminal):
 
     def _create_menu(self):
         self.menu = Gtk.Menu.new()
-        self.menu_copy = Gtk.MenuItem("Copy Text")
+        self.menu_copy = Gtk.MenuItem("Copy Text (Ctrl + Shift + C) ")
         self.menu.append(self.menu_copy)
-        self.menu_paste = Gtk.MenuItem("Paste Text")
+        self.menu_paste = Gtk.MenuItem("Paste Text (Ctrl + Shift + V)")
         self.menu.append(self.menu_paste)
-        self.menu_copy_link = Gtk.MenuItem("Copy Link")
+        self.menu_copy_link = Gtk.MenuItem("Copy Link (Ctrl + Shift + C)")
         self.menu.append(self.menu_copy_link)
-        self.menu_open_link = Gtk.MenuItem("Open Link in Browser")
+        self.menu_open_link = Gtk.MenuItem("Open Link in Browser (Ctrl + Click)")
         self.menu.append(self.menu_open_link)
         # connect menu items
         self.menu_copy.connect_object("activate", self.copy_clipboard, None)

--- a/sugarterm.py
+++ b/sugarterm.py
@@ -239,13 +239,18 @@ class SugarTerminal(Vte.Terminal):
             command += "\n"
         self.feed_child(command)
 
-    def copy_clipboard(self, widget=None):
-        if self.get_has_selection():
+    def copy_clipboard(self, widget=None, content=None):
+        if self.get_has_selection() and (content is None):
+            super(SugarTerminal, self).copy_clipboard()
+        elif content:
+            self.clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
+            self.clipboard.set_text(content, -1)
+            self.clipboard.store()
+        elif self.get_has_selection():
             super(SugarTerminal, self).copy_clipboard()
 
     def paste_clipboard(self, widget=None):
-        if self.get_has_selection():
-            super(SugarTerminal, self).paste_clipboard()
+        super(SugarTerminal, self).paste_clipboard()
 
     def add_matches(self):
         """Adds all regular expressions declared in

--- a/sugarterm.py
+++ b/sugarterm.py
@@ -41,7 +41,7 @@ from typing import Tuple
 from urllib.parse import unquote
 from urllib.parse import urlparse
 
-from time import sleep, time
+import time
 
 import gi
 from sugar3 import profile, env
@@ -117,8 +117,9 @@ class SugarTerminal(Vte.Terminal):
     """
     Just a vte.Terminal with some properties already set.
     """
-    def __init__(self):
+    def __init__(self, activity):
         super(SugarTerminal, self).__init__()
+        self.activity = activity
         self.conf = None
         self.conf_file = None
         self.add_matches()
@@ -447,7 +448,7 @@ class SugarTerminal(Vte.Terminal):
             font_size = self._font_size * Pango.SCALE
         else:
             font_size = font_desc.get_size()
-        font = self._get_conf(conf, 'font', 'Monospace')
+        font = self._get_conf(self.conf, 'font', 'Monospace')
         font_desc = Pango.FontDescription(font)
         font_desc.set_size(font_size)
         self.set_font(font_desc)

--- a/sugarterm.py
+++ b/sugarterm.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; -*-
 """
 Copyright (C) 2007-2013 Guake authors
+Copyright (C) 2020 SugarLabs
 Copyright (c) 2020 Srevin Saju <srevin03@gmail.com>
 
 This program is free software; you can redistribute it and/or

--- a/sugarterm.py
+++ b/sugarterm.py
@@ -1,0 +1,498 @@
+# -*- coding: utf-8; -*-
+"""
+Copyright (C) 2007-2013 Guake authors
+Copyright (c) 2020 Srevin Saju <srevin03@gmail.com>
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public
+License along with this program; if not, write to the
+Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+Boston, MA 02110-1301 USA
+
+This is a modified upstream source of the famous Guake Terminal
+https://github.com/Guake/guake/blob/master/guake/terminal.py
+
+"""
+import code
+import logging
+import os
+import re
+import shlex
+import signal
+import subprocess
+import sys
+import threading
+import uuid
+
+from enum import IntEnum
+from pathlib import Path
+from typing import Optional
+from typing import Tuple
+from urllib.parse import unquote
+from urllib.parse import urlparse
+
+from time import sleep
+
+import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('Vte', '2.91')  # vte-0.38
+
+from gi.repository import GLib
+from gi.repository import Gdk
+from gi.repository import GdkX11
+from gi.repository import Gtk
+from gi.repository import Pango
+from gi.repository import Vte
+
+
+TERMINAL_MATCH_TAGS = ('schema', 'http', 'https', 'email', 'ftp')
+
+# Beware this is a PRCE (Perl) regular expression, not a Python one!
+# Edit: use regex101.com with PCRE syntax
+TERMINAL_MATCH_EXPRS = [
+    "(news:|telnet:|nntp:|file:\/|https?:|ftps?:|webcal:)\/\/([-[:alnum:]]+"
+    "(:[-[:alnum:],?;.:\/!%$^\*&~\"#']+)?\@)?[-[:alnum:]]+(\.[-[:alnum:]]+)*"
+    "(:[0-9]{1,5})?(\/[-[:alnum:]_$.+!*(),;:@&=?\/~#'%]*[^].> \t\r\n,\\\"])?",
+    "(www|ftp)[-[:alnum:]]*\.[-[:alnum:]]+(\.[-[:alnum:]]+)*(:[0-9]{1,5})?"
+    "(\/[-[:alnum:]_$.+!*(),;:@&=?\/~#%]*[^]'.>) \t\r\n,\\\"])?",
+    "(mailto:)?[-[:alnum:]][-[:alnum:].]*@[-[:alnum:]]+\.[-[:alnum:]]+(\\.[-[:alnum:]]+)*"
+]
+
+log = logging
+
+libutempter = None
+try:
+    # this allow to run some commands that requires libuterm to
+    # be injected in current process, as: wall
+    from atexit import register as at_exit_call
+    from ctypes import cdll
+    libutempter = cdll.LoadLibrary('libutempter.so.0')
+    if libutempter is not None:
+        # We absolutely need to remove the old tty from the utmp !!!
+        at_exit_call(libutempter.utempter_remove_added_record)
+except Exception as e:
+    libutempter = None
+    sys.stderr.write("[WARN] ===================================================================\n")
+    sys.stderr.write("[WARN] Unable to load the library libutempter !\n")
+    sys.stderr.write(
+        "[WARN] Some feature might not work:\n"
+        "[WARN]  - 'exit' command might freeze the terminal instead of closing the tab\n"
+        "[WARN]  - the 'wall' command is known to work badly\n"
+    )
+    sys.stderr.write("[WARN] Error: " + str(e) + '\n')
+    sys.stderr.write(
+        "[WARN] ===================================================================²\n"
+    )
+
+
+def halt(loc):
+    code.interact(local=loc)
+
+
+__all__ = ['SugarTerminal']
+
+# pylint: enable=anomalous-backslash-in-string
+
+
+class DropTargets(IntEnum):
+    URIS = 0
+    TEXT = 1
+
+
+class SugarTerminal(Vte.Terminal):
+    """
+    Just a vte.Terminal with some properties already set.
+    """
+    def __init__(self):
+        super(SugarTerminal, self).__init__()
+
+        self.add_matches()
+        self.handler_ids = []
+        self.handler_ids.append(self.connect('button-press-event', self.button_press))
+        self.connect('child-exited', self.on_child_exited)  # Call on_child_exited, don't remove it
+        self.matched_value = ''
+        self.font_scale_index = 0
+        self._pid = None
+        # self.custom_bgcolor = None
+        # self.custom_fgcolor = None
+        self.found_link = None
+        self.uuid = uuid.uuid4()
+
+        # Custom colors
+        self.custom_bgcolor = None
+        self.custom_fgcolor = None
+        self.custom_palette = None
+
+        self.setup_drag_and_drop()
+
+    def setup_drag_and_drop(self):
+        self.targets = Gtk.TargetList()
+        self.targets.add_uri_targets(DropTargets.URIS)
+        self.targets.add_text_targets(DropTargets.TEXT)
+        self.drag_dest_set(Gtk.DestDefaults.ALL, [], Gdk.DragAction.COPY)
+        self.drag_dest_set_target_list(self.targets)
+        self.connect('drag-data-received', self.on_drag_data_received)
+
+    def get_uuid(self):
+        return self.uuid
+
+    @property
+    def pid(self):
+        return self._pid
+
+    @pid.setter
+    def pid(self, pid):
+        self._pid = pid
+
+    def feed_child(self, resolved_cmdline):
+        if (Vte.MAJOR_VERSION, Vte.MINOR_VERSION) >= (0, 42):
+            encoded = resolved_cmdline.encode("utf-8")
+            try:
+                super().feed_child_binary(encoded)
+            except TypeError:
+                # The doc doest not say clearly at which version the feed_child* function has lost
+                # the "len" parameter :(
+                super().feed_child(resolved_cmdline, len(resolved_cmdline))
+        else:
+            super().feed_child(resolved_cmdline, len(resolved_cmdline))
+
+    def execute_command(self, command):
+        if command[-1] != '\n':
+            command += "\n"
+        self.feed_child(command)
+
+    def copy_clipboard(self):
+        if self.get_has_selection():
+            super(SugarTerminal, self).copy_clipboard()
+        elif self.matched_value:
+            log.warning('Not Implemented Sugar')
+
+    def add_matches(self):
+        """Adds all regular expressions declared in
+        guake.globals.TERMINAL_MATCH_EXPRS to the terminal to make vte
+        highlight text that matches them.
+        """
+        try:
+            # NOTE: PCRE2_UTF | PCRE2_NO_UTF_CHECK | PCRE2_MULTILINE
+            # reference from vte/bindings/vala/app.vala, flags = 0x40080400u
+            # also ref: https://mail.gnome.org/archives/commits-list/2016-September/msg06218.html
+            VTE_REGEX_FLAGS = 0x40080400
+            for expr in TERMINAL_MATCH_EXPRS:
+                tag = self.match_add_regex(
+                    Vte.Regex.new_for_match(expr, len(expr), VTE_REGEX_FLAGS), 0
+                )
+                self.match_set_cursor_type(tag, Gdk.CursorType.HAND2)
+
+
+        except (GLib.Error, AttributeError) as e:  # pylint: disable=catching-non-exception
+            try:
+                compile_flag = 0
+                if (Vte.MAJOR_VERSION, Vte.MINOR_VERSION) >= (0, 44):
+                    compile_flag = GLib.RegexCompileFlags.MULTILINE
+                for expr in TERMINAL_MATCH_EXPRS:
+                    tag = self.match_add_gregex(GLib.Regex.new(expr, compile_flag, 0), 0)
+                    self.match_set_cursor_type(tag, Gdk.CursorType.HAND2)
+
+
+            except GLib.Error as e:  # pylint: disable=catching-non-exception
+                log.error(
+                    "ERROR: PCRE2 does not seems to be enabled on your system. "
+                    "Quick Edit and other Ctrl+click features are disabled. "
+                    "Please update your VTE package or contact your distribution to ask "
+                    "to enable regular expression support in VTE. Exception: '%s'", str(e)
+                )
+
+    def get_current_directory(self):
+        directory = os.path.expanduser('~')
+        if self.pid is not None:
+            try:
+                cwd = os.readlink("/proc/{}/cwd".format(self.pid))
+            except Exception as e:
+                return directory
+            if os.path.exists(cwd):
+                directory = cwd
+        return directory
+
+    def is_file_on_local_server(self, text) -> Tuple[Optional[Path], Optional[int], Optional[int]]:
+        """Test if the provided text matches a file on local server
+
+        Supports:
+         - absolute path
+         - relative path (using current working directory)
+         - file:line syntax
+         - file:line:colum syntax
+
+        Args:
+            text (str): candidate for file search
+
+        Returns
+            - Tuple(None, None, None) if the provided text does not match anything
+            - Tuple(file path, None, None) if only a file path is found
+            - Tuple(file path, linenumber, None) if line number is found
+            - Tuple(file path, linenumber, columnnumber) if line and column numbers are found
+        """
+        lineno = None
+        colno = None
+        py_func = None
+        # "<File>:<line>:<col>"
+        m = re.compile(r"(.*)\:(\d+)\:(\d+)$").match(text)
+        if m:
+            text = m.group(1)
+            lineno = m.group(2)
+            colno = m.group(3)
+        else:
+            # "<File>:<line>"
+            m = re.compile(r"(.*)\:(\d+)$").match(text)
+            if m:
+                text = m.group(1)
+                lineno = m.group(2)
+            else:
+                # "<File>::<python_function>"
+                m = re.compile(r"^(.*)\:\:([a-zA-Z0-9\_]+)$").match(text)
+                if m:
+                    text = m.group(1)
+                    py_func = m.group(2).strip()
+
+        def find_lineno(text, pt, lineno, py_func):
+            # print("text={!r}, pt={!r}, lineno={!r}, py_func={!r}".format(text,
+            #                                                              pt, lineno, py_func))
+            if lineno:
+                return lineno
+            if not py_func:
+                return
+            with pt.open() as f:
+                for i, line in enumerate(f.readlines()):
+                    if line.startswith("def {}".format(py_func)):
+                        return i + 1
+                        break
+
+        pt = Path(text)
+        log.debug("checking file existance: %r", pt)
+        try:
+            if pt.exists():
+                lineno = find_lineno(text, pt, lineno, py_func)
+                log.info("File exists: %r, line=%r", pt.absolute().as_posix(), lineno)
+                return (pt, lineno, colno)
+            log.debug("No file found matching: %r", text)
+            cwd = self.get_current_directory()
+            pt = Path(cwd) / pt
+            log.debug("checking file existance: %r", pt)
+            if pt.exists():
+                lineno = find_lineno(text, pt, lineno, py_func)
+                log.info("File exists: %r, line=%r", pt.absolute().as_posix(), lineno)
+                return (pt, lineno, colno)
+            log.debug("file does not exist: %s", str(pt))
+        except OSError:
+            log.debug("not a file name: %r", text)
+        return (None, None, None)
+
+    def button_press(self, terminal, event):
+        """Handles the button press event in the terminal widget. If
+        any match string is caught, another application is open to
+        handle the matched resource uri.
+        """
+        self.matched_value = ''
+        if (Vte.MAJOR_VERSION, Vte.MINOR_VERSION) >= (0, 46):
+            matched_string = self.match_check_event(event)
+        else:
+            matched_string = self.match_check(
+                int(event.x / self.get_char_width()), int(event.y / self.get_char_height())
+            )
+
+        self.found_link = None
+
+        if event.button == 1 and (event.get_state() & Gdk.ModifierType.CONTROL_MASK):
+            if (Vte.MAJOR_VERSION, Vte.MINOR_VERSION) > (0, 50):
+                s = self.hyperlink_check_event(event)
+            else:
+                s = None
+            if s is not None:
+                self._on_ctrl_click_matcher((s, None))
+            elif matched_string and matched_string[0]:
+                self._on_ctrl_click_matcher(matched_string)
+        elif event.button == 3 and matched_string:
+            self.found_link = self.handleTerminalMatch(matched_string)
+            self.matched_value = matched_string[0]
+
+    def on_child_exited(self, target, status, *user_data):
+        if libutempter is not None:
+            if self.get_pty() is not None:
+                libutempter.utempter_remove_record(self.get_pty().get_fd())
+
+    def on_drag_data_received(self, widget, drag_context, x, y, data, info, time):
+        if info == DropTargets.URIS:
+            uris = data.get_uris()
+            for uri in uris:
+                path = Path(unquote(urlparse(uri).path))
+                self.feed_child(shlex.quote(str(path.absolute())) + ' ')
+        elif info == DropTargets.TEXT:
+            text = data.get_text()
+            if text:
+                self.feed_child(text)
+
+
+    def _on_ctrl_click_matcher(self, matched_string):
+        value, tag = matched_string
+        found_matcher = False
+        log.debug("matched string: %s", matched_string)
+        # First searching in additional matchers
+
+        if not found_matcher:
+            self.found_link = self.handleTerminalMatch(matched_string)
+            if self.found_link:
+                self.browse_link_under_cursor()
+
+    def handleTerminalMatch(self, matched_string):
+        value, tag = matched_string
+        log.debug("found tag: %r, item: %r", tag, value)
+        if tag in TERMINAL_MATCH_TAGS:
+            if TERMINAL_MATCH_TAGS[tag] == 'schema':
+                # value here should not be changed, it is right and
+                # ready to be used.
+                pass
+            elif TERMINAL_MATCH_TAGS[tag] == 'http':
+                value = 'http://%s' % value
+            elif TERMINAL_MATCH_TAGS[tag] == 'https':
+                value = 'https://%s' % value
+            elif TERMINAL_MATCH_TAGS[tag] == 'ftp':
+                value = 'ftp://%s' % value
+            elif TERMINAL_MATCH_TAGS[tag] == 'email':
+                value = 'mailto:%s' % value
+
+        if value:
+            return value
+
+    def get_link_under_cursor(self):
+        return self.found_link
+
+    def browse_link_under_cursor(self):
+        if not self.found_link:
+            return
+        log.debug("Opening link: %s", self.found_link)
+        cmd = ["xdg-open", self.found_link]
+        subprocess.Popen(cmd, shell=False)
+
+    def increase_font_size(self):
+        self.font_scale += 1
+
+    def decrease_font_size(self):
+        self.font_scale -= 1
+
+    def kill(self):
+        pid = self.pid
+        threading.Thread(target=self.delete_shell, args=(pid, )).start()
+        # start_new_thread(self.delete_shell, (pid,))
+
+    def delete_shell(self, pid):
+        """Kill the shell with SIGHUP
+
+        NOTE: Leave it alone, DO NOT USE os.waitpid
+
+        > sys:1: Warning: GChildWatchSource: Exit status of a child process was requested but
+                 ECHILD was received by waitpid(). See the documentation of
+                 g_child_watch_source_new() for possible causes.
+
+        g_child_watch_source_new() documentation:
+            https://developer.gnome.org/glib/stable/glib-The-Main-Event-Loop.html#g-child-watch-source-new
+
+        On POSIX platforms, the following restrictions apply to this API due to limitations
+        in POSIX process interfaces:
+            ...
+            * the application must not wait for pid to exit by any other mechanism,
+              including waitpid(pid, ...) or a second child-watch source for the same pid
+            ...
+        For this reason, we should not call os.waitpid(pid, ...), leave it to OS
+        """
+        try:
+            os.kill(pid, signal.SIGHUP)
+        except OSError:
+            pass
+
+    def set_color_foreground(self, font_color, *args, **kwargs):
+        real_fgcolor = self.custom_fgcolor if self.custom_fgcolor else font_color
+        super(SugarTerminal, self).set_color_foreground(real_fgcolor, *args, **kwargs)
+
+    def set_color_background(self, bgcolor, *args, **kwargs):
+        real_bgcolor = self.custom_bgcolor if self.custom_bgcolor else bgcolor
+        super(SugarTerminal, self).set_color_background(real_bgcolor, *args, **kwargs)
+
+    def set_color_bold(self, font_color, *args, **kwargs):
+        real_fgcolor = self.custom_fgcolor if self.custom_fgcolor else font_color
+        super(SugarTerminal, self).set_color_bold(real_fgcolor, *args, **kwargs)
+
+    def set_colors(self, font_color, bg_color, palette_list, *args, **kwargs):
+        real_bgcolor = self.custom_bgcolor if self.custom_bgcolor else bg_color
+        real_fgcolor = self.custom_fgcolor if self.custom_fgcolor else font_color
+        real_palette = self.custom_palette if self.custom_palette else palette_list
+        super(SugarTerminal,
+              self).set_colors(real_fgcolor, real_bgcolor, real_palette, *args, **kwargs)
+
+    def set_color_foreground_custom(self, fgcolor, *args, **kwargs):
+        """Sets custom foreground color for this terminal"""
+        print('set_color_foreground_custom: %s' % self.uuid)
+        self.custom_fgcolor = fgcolor
+        super(SugarTerminal, self).set_color_foreground(self.custom_fgcolor, *args, **kwargs)
+
+    def set_color_background_custom(self, bgcolor, *args, **kwargs):
+        """Sets custom background color for this terminal"""
+        self.custom_bgcolor = bgcolor
+        super(SugarTerminal, self).set_color_background(self.custom_bgcolor, *args, **kwargs)
+
+    def reset_custom_colors(self):
+        self.custom_fgcolor = None
+        self.custom_bgcolor = None
+        self.custom_palette = None
+
+    @staticmethod
+    def _color_to_list(color):
+        """This method is used for serialization."""
+        if color is None:
+            return None
+        return [color.red, color.green, color.blue, color.alpha]
+
+    @staticmethod
+    def _color_from_list(color_list):
+        """This method is used for deserialization."""
+        return Gdk.RGBA(
+            red=color_list[0], green=color_list[1], blue=color_list[2], alpha=color_list[3]
+        )
+
+    def get_custom_colors_dict(self):
+        """Returns dictionary of custom colors."""
+        return {
+            'fg_color': self._color_to_list(self.custom_fgcolor),
+            'bg_color': self._color_to_list(self.custom_bgcolor),
+            'palette': [self._color_to_list(col)
+                        for col in self.custom_palette] if self.custom_palette else None,
+        }
+
+    def set_custom_colors_from_dict(self, colors_dict):
+        if not isinstance(colors_dict, dict):
+            return
+
+        bg_color = colors_dict.get('bg_color', None)
+        if isinstance(bg_color, list):
+            self.custom_bgcolor = self._color_from_list(bg_color)
+        else:
+            self.custom_bgcolor = None
+
+        fg_color = colors_dict.get('fg_color', None)
+        if isinstance(fg_color, list):
+            self.custom_fgcolor = self._color_from_list(fg_color)
+        else:
+            self.custom_fgcolor = None
+
+        palette = colors_dict.get('palette', None)
+        if isinstance(palette, list):
+            self.custom_palette = [self._color_from_list(col) for col in palette]
+        else:
+            self.custom_palette = None

--- a/terminal.py
+++ b/terminal.py
@@ -216,7 +216,8 @@ class TerminalActivity(activity.Activity):
             self._theme_state = "dark"
         else:
             self._theme_state = "light"
-        self._update_custom_theme(previous_theme['fg_color'], previous_theme['bg_color'])
+        self._update_custom_theme(
+            previous_theme['fg_color'], previous_theme['bg_color'])
         self._update_theme()
 
     def _update_theme(self):
@@ -580,7 +581,8 @@ class TerminalActivity(activity.Activity):
 
         data = {}
         data['current-tab'] = self._notebook.get_current_page()
-        data['theme'] = 'custom'  # make sures this doesn't conflict with older terminal version
+        # make sures this doesn't conflict with older terminal version
+        data['theme'] = 'custom'
         data['theme_hex'] = self._theme_colors['custom']
         data['tabs'] = []
 

--- a/terminal.py
+++ b/terminal.py
@@ -247,19 +247,19 @@ class TerminalActivity(activity.Activity):
         view_toolbar.insert(self._theme_toggler, -1)
         self._theme_toggler.show()
 
-        fg_color = ColorToolButton('color-preview')
-        fg_color._tooltip = "Set Foreground Text color"
-        fg_color.set_title('Foreground Color')
-        fg_color.connect('notify::color', self.__fg_color_notify_cb)
-        view_toolbar.insert(fg_color, -1)
-        fg_color.show()
+        self.fg_color_palette = ColorToolButton('color-preview')
+        self.fg_color_palette._tooltip = "Set Foreground Text color"
+        self.fg_color_palette.set_title('Foreground Color')
+        self.fg_color_palette.connect('notify::color', self.__fg_color_notify_cb)
+        view_toolbar.insert(self.fg_color_palette, -1)
+        self.fg_color_palette.show()
 
-        bg_color = ColorToolButton('color-preview')
-        bg_color._tooltip = "Set Background color"
-        bg_color.set_title('Background Color')
-        bg_color.connect('notify::color', self.__bg_color_notify_cb)
-        view_toolbar.insert(bg_color, -1)
-        bg_color.show()
+        self.bg_color_palette = ColorToolButton('color-preview')
+        self.bg_color_palette._tooltip = "Set Background color"
+        self.bg_color_palette.set_title('Background Color')
+        self.bg_color_palette.connect('notify::color', self.__bg_color_notify_cb)
+        view_toolbar.insert(self.bg_color_palette, -1)
+        self.bg_color_palette.show()
 
         sep = Gtk.SeparatorToolItem()
         view_toolbar.insert(sep, -1)
@@ -564,6 +564,8 @@ class TerminalActivity(activity.Activity):
             self._theme_colors['custom'] = data['theme_hex']
         else:
             self._theme_colors['custom'] = self._theme_colors[data['theme']]
+        self.fg_color_palette.set_color(Gdk.Color.parse(self._theme_colors['custom']['fg_color'])[1])
+        self.bg_color_palette.set_color(Gdk.Color.parse(self._theme_colors['custom']['bg_color'])[1])
         self._update_theme()
 
         # Create new tabs from saved state.

--- a/terminal.py
+++ b/terminal.py
@@ -49,12 +49,13 @@ from sugar3.activity.widgets import ActivityToolbarButton
 from sugar3.activity.widgets import StopButton
 from sugar3.activity import activity
 from sugar3 import env
+from sugar3.graphics.colorbutton import ColorToolButton
 
 from widgets import BrowserNotebook
 from widgets import TabLabel
 
 from helpbutton import HelpButton
-
+from sugarterm import SugarTerminal
 
 MASKED_ENVIRONMENT = [
     'DBUS_SESSION_BUS_ADDRESS',
@@ -80,6 +81,7 @@ try:
 except:
     # version is not published in old versions of vte
     pass
+
 
 
 class TerminalActivity(activity.Activity):
@@ -111,6 +113,11 @@ class TerminalActivity(activity.Activity):
         edit_toolbar.show()
         toolbar_box.toolbar.insert(edit_toolbar_button, -1)
         edit_toolbar_button.show()
+
+        color = ColorToolButton('color')
+        color.connect('notify::color', self.__color_notify_cb)
+        toolbar_box.toolbar.insert(color, -1)
+        color.show()
 
         view_toolbar = self._create_view_toolbar()
         view_toolbar_button = ToolbarButton(
@@ -346,7 +353,7 @@ class TerminalActivity(activity.Activity):
         return True
 
     def _create_tab(self, tab_state):
-        vt = Vte.Terminal()
+        vt = SugarTerminal()
         vt.connect("child-exited", self.__tab_child_exited_cb)
         vt.connect("window-title-changed", self.__tab_title_changed_cb)
 
@@ -669,3 +676,4 @@ class TerminalActivity(activity.Activity):
         n = vt.props.scrollback_lines
         vt.set_scrollback_lines(0)
         vt.set_scrollback_lines(n)
+

--- a/terminal.py
+++ b/terminal.py
@@ -19,7 +19,6 @@
 import os
 import sys
 import json
-import configparser
 import logging
 from gettext import gettext as _
 
@@ -48,7 +47,6 @@ from sugar3.activity.widgets import EditToolbar
 from sugar3.activity.widgets import ActivityToolbarButton
 from sugar3.activity.widgets import StopButton
 from sugar3.activity import activity
-from sugar3 import env
 from sugar3.graphics.colorbutton import ColorToolButton, get_svg_color_string
 
 from widgets import BrowserNotebook
@@ -178,27 +176,11 @@ class TerminalActivity(activity.Activity):
         edit_toolbar.paste.connect('clicked', self.__paste_cb)
         edit_toolbar.paste.props.accelerator = '<Ctrl><Shift>V'
 
-        fg_color = ColorToolButton('color-preview')
-        fg_color._tooltip = "Set Foreground Text color"
-        fg_color.set_title('Foreground Color')
-        fg_color.connect('notify::color', self.__fg_color_notify_cb)
-        edit_toolbar.insert(fg_color, -1)
-        fg_color.show()
-
-        bg_color = ColorToolButton('color-preview')
-        bg_color._tooltip = "Set Background color"
-        bg_color.set_title('Background Color')
-        bg_color.connect('notify::color', self.__bg_color_notify_cb)
-        edit_toolbar.insert(bg_color, -1)
-        bg_color.show()
-
         clear = ToolButton('edit-clear')
         clear.set_tooltip(_('Clear scrollback'))
         clear.connect('clicked', self.__clear_cb)
         edit_toolbar.insert(clear, -1)
         clear.show()
-
-
         return edit_toolbar
 
     def __copy_cb(self, button):
@@ -261,6 +243,20 @@ class TerminalActivity(activity.Activity):
         self._theme_toggler.connect('clicked', self._toggled_theme)
         view_toolbar.insert(self._theme_toggler, -1)
         self._theme_toggler.show()
+
+        fg_color = ColorToolButton('color-preview')
+        fg_color._tooltip = "Set Foreground Text color"
+        fg_color.set_title('Foreground Color')
+        fg_color.connect('notify::color', self.__fg_color_notify_cb)
+        view_toolbar.insert(fg_color, -1)
+        fg_color.show()
+
+        bg_color = ColorToolButton('color-preview')
+        bg_color._tooltip = "Set Background color"
+        bg_color.set_title('Background Color')
+        bg_color.connect('notify::color', self.__bg_color_notify_cb)
+        view_toolbar.insert(bg_color, -1)
+        bg_color.show()
 
         sep = Gtk.SeparatorToolItem()
         view_toolbar.insert(sep, -1)
@@ -393,7 +389,7 @@ class TerminalActivity(activity.Activity):
         return True
 
     def _create_tab(self, tab_state):
-        vt = SugarTerminal()
+        vt = SugarTerminal(self)
         vt.connect("child-exited", self.__tab_child_exited_cb)
         vt.connect("window-title-changed", self.__tab_title_changed_cb)
 
@@ -628,7 +624,6 @@ class TerminalActivity(activity.Activity):
                          'scrollback': scrollback_lines}
 
             data['tabs'].append(tab_state)
-        print(data)
         fd = open(file_path, 'w')
         text = json.dumps(data)
         fd.write(text)

--- a/terminal.py
+++ b/terminal.py
@@ -258,6 +258,7 @@ class TerminalActivity(activity.Activity):
         self.bg_color_palette._tooltip = "Set Background color"
         self.bg_color_palette.set_title('Background Color')
         self.bg_color_palette.connect('notify::color', self.__bg_color_notify_cb)
+        self.bg_color_palette.set_color(Gdk.Color.parse('#FFFFFF')[1])
         view_toolbar.insert(self.bg_color_palette, -1)
         self.bg_color_palette.show()
 

--- a/terminal.py
+++ b/terminal.py
@@ -24,6 +24,7 @@ from gettext import gettext as _
 
 import gi
 
+
 vs = {'Gtk': '3.0', 'SugarExt': '1.0', 'SugarGestures': '1.0'}
 for api, ver in vs.items():
     gi.require_version(api, ver)
@@ -182,6 +183,7 @@ class TerminalActivity(activity.Activity):
         edit_toolbar.insert(clear, -1)
         clear.show()
         return edit_toolbar
+
 
     def __copy_cb(self, button):
         vt = self._notebook.get_nth_page(self._notebook.get_current_page()).vt
@@ -636,3 +638,4 @@ class TerminalActivity(activity.Activity):
         n = vt.props.scrollback_lines
         vt.set_scrollback_lines(0)
         vt.set_scrollback_lines(n)
+


### PR DESCRIPTION
Fixes https://github.com/sugarlabs/terminal-activity/issues/27.

With reference to pull request #35.

> At the moment, a URL displayed by an application has to be copied and pasted into Browse.

> * [x]  research how GNOME Terminal and other Terminal emulators support URLs displayed,

for my case study, I have used the code of the famous Guake Terminal (based on Python3, GTK and VTE 2.91)

> * URLs are displayed without any change,

URLs are shown as normal text whenever there is  output URL. URLs are only highlighted on mouse over, hence reducing CPU cycles

> * URLs obscured by OSC 8 escape sequence show the link text,



> * mouse-over underlines the URL or the link text and changes mouse cursor from vertical insertion to pointing finger,

cursor is changed to pointing finger

> * clicking on the link does nothing,
> * ctrl-clicking on the link launches browser,

`ctrl + click`writes a journal instance and opens a browse activity with the URL 

> * right-click on link shows menu with "Open Link" and "Copy Link" options for URLs, and "Open Hyperlink" and "Copy Hyperlink" options for link text,

as sugar doesn't use right click menu in most of the activities, I haven't considered this in the current PR.

> * [ ]  design the user experience, and work to consensus,
> * URLs are to be displayed without any change,
> * URLs obscured by OSC 8 escape sequence are to show the link text in the Terminal, and the URL when the mouse cursor hovers over the link,
> * mouse-over is to underline the URL or the link text and change mouse cursor from vertical insertion to pointing finger,
> * clicking on the link is to do nothing,
> * ctrl-clicking on the link is to launch Browse to display the URL,
> * right-click on link is to show a menu with "Open Link" and "Copy Link" options for URLs, and "Open Hyperlink" and "Copy Hyperlink" options for link text,
> * [ ]  implement similar handling in Sugar Terminal

Implemeted all of the above changes except right click in the current PR.

if a user works with servers on the terminal, it was previously very difficult to copy paste into a browser screen too. right click and copying the link was not intuitive for a student, because, it wastes time, and resources. with a URL support, a student is likely faster to involve his URL based work from the terminal, and save each instance into a Journal instance, so that it can be accessed any time by the student. Finally, I considered using different journal instances, because, it helps to differentiate time at which it was created and helps to maintain a log of what the user has done. (else it will be like a programmer rebasing and editing commit histories of the past)

Second, color of background and foreground. Color is an important part of a terminal. using high contrast colors on the terminal can make it look more scary and can also hurt eyes. with the Colour chooser, a student can choose the colors of choice making it very relatable and smooth. research proves that white text on slate grey or less bluish colors are better for eyes too. and it completely dependends on the user to chose the terminal. using custom colours of the terminal can make the first experience of a user with the terminal refreshing

## Screenshots
![srevinsaju-sugarterm](https://user-images.githubusercontent.com/48695438/72682771-c8415980-3ae1-11ea-8edb-0b801eb1827b.gif)

Tested it on : 
* Sugar Debain Live Build
* Sugar DE

**What I did**
* Saw the task on GitHub
* (Lol, didn't check the PR, only saw the issue)
* Saw @quozl mentioning on Gnome Terminal
* Open Github, topic `Terminal`, Language == Python, Get Guake's `terminal.py`
* Got stuck on how to open browse activity, came back to task, checked the PR
* Realized it late, @nswarup14 used Guake's sources, but I used the same Guake's terminal.py with a little bit modification. I do not intend to remove Guake's GNU GPL License header, which the previous author had did, retained the change color methods.
* Cherry picked https://github.com/sugarlabs/terminal-activity/pull/38/commits/c1dd36292d5599a9eced1f59ba5cd33fbb90a66f from @nswarup14 's PR.
* Add custom color toolbar (got a good experience from https://github.com/sugarlabs/physics/issues/41 as GCI task again)
* Move all configuration to sugarterm.py

**Disclaimer:**
Guake's `terminal.py` is licensed under GNU GPL v2. All instances of `guake` and `GuakeTerminal` has been renamed to `SugarTerminal` or `sugarterm,py` appropriately. Additional sugary features were added. 

Please review @quozl @walterbender @Hrishi1999