### PR TITLE
fixes Gdk.RGBA color parse error

### DIFF
--- a/sugarterm.py
+++ b/sugarterm.py
@@ -508,6 +508,11 @@ class SugarTerminal(Vte.Terminal):
         super(SugarTerminal, self).set_color_bold(
             real_fgcolor, *args, **kwargs)
 
+    def _to_rgba(self, color):
+        rgba = Gdk.RGBA()
+        rgba.parse(color)
+        return rgba
+
     def set_term_colors(self, custom_colors):
         fg_color = custom_colors['fg_color']
         bg_color = custom_colors['bg_color']
@@ -519,8 +524,9 @@ class SugarTerminal(Vte.Terminal):
             # in Fedora 21 we get a exception
             # TypeError: argument foreground: Expected Gdk.RGBA,
             # but got gi.overrides.Gdk.Color
-            self.set_colors(Gdk.RGBA(*Gdk.color_parse(fg_color).to_floats()),
-                            Gdk.RGBA(*Gdk.color_parse(bg_color).to_floats()), [])
+
+            self.set_colors(self._to_rgba(fg_color),
+                            self._to_rgba(bg_color), [])
 
     def get_custom_colors_dict(self):
         """Returns dictionary of custom colors."""

--- a/terminal.py
+++ b/terminal.py
@@ -237,6 +237,12 @@ class TerminalActivity(activity.Activity):
             vt = self._notebook.get_nth_page(i).vt
             vt.set_term_colors(self._theme_colors['custom'])
 
+
+    def _to_rgba(self,color):
+        rgba = Gdk.RGBA()
+        rgba.parse(color)
+        return rgba
+
     def _create_view_toolbar(self):  # Color changer and Zoom toolbar
         view_toolbar = Gtk.Toolbar()
 
@@ -258,7 +264,8 @@ class TerminalActivity(activity.Activity):
         self.bg_color_palette._tooltip = "Set Background color"
         self.bg_color_palette.set_title('Background Color')
         self.bg_color_palette.connect('notify::color', self.__bg_color_notify_cb)
-        self.bg_color_palette.set_color(Gdk.Color.parse('#FFFFFF')[1])
+
+        self.bg_color_palette.set_color(self._to_rgba('#FFFFFF'))
         view_toolbar.insert(self.bg_color_palette, -1)
         self.bg_color_palette.show()
 
@@ -565,8 +572,9 @@ class TerminalActivity(activity.Activity):
             self._theme_colors['custom'] = data['theme_hex']
         else:
             self._theme_colors['custom'] = self._theme_colors[data['theme']]
-        self.fg_color_palette.set_color(Gdk.Color.parse(self._theme_colors['custom']['fg_color'])[1])
-        self.bg_color_palette.set_color(Gdk.Color.parse(self._theme_colors['custom']['bg_color'])[1])
+
+        self.fg_color_palette.set_color(self._to_rgba(self._theme_colors['custom']['fg_color']))
+        self.bg_color_palette.set_color(self._to_rgba(self._theme_colors['custom']['bg_color']))
         self._update_theme()
 
         # Create new tabs from saved state.


### PR DESCRIPTION
As Gdk.Color is deprecated , change to Gdk.RGBA is important. I have tested the activity is working as before.