### PR TITLE
Reorder function call to create notebook before toolbar init #39

### DIFF
--- a/terminal.py
+++ b/terminal.py
@@ -103,7 +103,19 @@ class TerminalActivity(activity.Activity):
         self._theme_state = "light"
 
         self._font_size = FONT_SIZE
+        self.build_notebook()
+        self.build_toolbar()
 
+    def build_notebook(self):
+        self._notebook = BrowserNotebook()
+        self._notebook.connect("tab-added", self.__open_tab_cb)
+        self._notebook.set_property("tab-pos", Gtk.PositionType.TOP)
+        self._notebook.set_scrollable(True)
+        self._notebook.show()
+        self.set_canvas(self._notebook)
+        self._create_tab(None)
+
+    def build_toolbar(self):
         toolbar_box = ToolbarBox()
 
         activity_button = ActivityToolbarButton(self)
@@ -148,16 +160,6 @@ class TerminalActivity(activity.Activity):
 
         self.set_toolbar_box(toolbar_box)
         toolbar_box.show()
-
-        self._notebook = BrowserNotebook()
-        self._notebook.connect("tab-added", self.__open_tab_cb)
-        self._notebook.set_property("tab-pos", Gtk.PositionType.TOP)
-        self._notebook.set_scrollable(True)
-        self._notebook.show()
-
-        self.set_canvas(self._notebook)
-
-        self._create_tab(None)
 
     def fullscreen(self):
         self._notebook.set_show_tabs(False)


### PR DESCRIPTION
Fixes #39

Creates notebook instance before creating toolbar
Toolbar includes callback functions to handle zoom.
To prevent `build_toolbar` callbacks; we have to
create `Gtk.Notebook` before initialization of the
toolbar