### PR TITLE
Fix issues in Theme toggling button

### DIFF
--- a/terminal.py
+++ b/terminal.py
@@ -213,13 +213,16 @@ class TerminalActivity(activity.Activity):
         self._theme_colors['custom']['bg_color'] = bg_color
 
     def _toggled_theme(self, button):
-        previous_theme = self._theme_colors[self._theme_state]
         if self._theme_state == "dark":
             self._theme_state = "light"
         elif self._theme_state == "light":
             self._theme_state = "dark"
         else:
-            self._theme_state = "light"
+            if self._theme_toggler.get_icon_name() == "light-theme":
+                self._theme_state = "light"
+            else:
+                self._theme_state = "dark"
+        previous_theme = self._theme_colors[self._theme_state]
         self._update_custom_theme(
             previous_theme['fg_color'], previous_theme['bg_color'])
         self._update_theme()
@@ -229,9 +232,6 @@ class TerminalActivity(activity.Activity):
             self._theme_toggler.set_icon_name('dark-theme')
             self._theme_toggler.set_tooltip('Switch to Dark Theme')
         elif self._theme_state == "dark":
-            self._theme_toggler.set_icon_name('light-theme')
-            self._theme_toggler.set_tooltip('Switch to Light Theme')
-        else:
             self._theme_toggler.set_icon_name('light-theme')
             self._theme_toggler.set_tooltip('Switch to Light Theme')
 


### PR DESCRIPTION
Multiple clicks were required to switch themes using the toggle
theme button.
previous_theme was set before theme was changed, causing the theme to
change only in the next click.
Through inspection using pdb, found that setting the default bg_color to white,
has set the _theme_state to `custom` during creation of view_toolbar. The functions
_toggled_theme() and _update_theme() handled switching of the Theme toggler icon,
 tooltip incorrectly.

Theme toggler button icon and tooltip always set to the light theme
when the custom color option was used.
Now the Theme toggler's theme icon and tooltip aren't changed when a
custom theme is selected.
Theme toggler icon and tooltip now correspond to the correct theme.

Regressions introduced in d2d243c