### PR TITLE
Fix theme not switching to dark on toggle

### DIFF
--- a/terminal.py
+++ b/terminal.py
@@ -218,7 +218,8 @@ class TerminalActivity(activity.Activity):
         elif self._theme_state == "light":
             self._theme_state = "dark"
         else:
-            if self._theme_toggler.get_icon_name() == "light-theme":
+            if self._theme_toggler.get_icon_name() == "light-theme" \
+                    or self._theme_colors['custom'] == self._theme_colors['dark']:
                 self._theme_state = "light"
             else:
                 self._theme_state = "dark"
@@ -234,6 +235,11 @@ class TerminalActivity(activity.Activity):
         elif self._theme_state == "dark":
             self._theme_toggler.set_icon_name('light-theme')
             self._theme_toggler.set_tooltip('Switch to Light Theme')
+        else:
+            # If custom color is dark, update the theme toggler
+            if self._theme_colors['custom'] == self._theme_colors['dark']:
+                self._theme_toggler.set_icon_name('light-theme')
+                self._theme_toggler.set_tooltip('Switch to Light Theme')
 
         for i in range(self._notebook.get_n_pages()):
             vt = self._notebook.get_nth_page(i).vt


### PR DESCRIPTION
The way the custom colors have been implemented is such that any theme
 chosen- light/dark/custom overrides the custom colors defined. So after
 using the dark theme, closing, and opening again the theme is actually
 'custom' but with the dark colors applied.
Pressing <shift><ctrl><I> toggles it to dark mode (from custom) and
then to light mode (from dark) on the second try.

The fix i toggles to light if the custom colors match the dark colors (or)
 icon is 'light-theme'.

Regression introduced in 4274006

Fixes #45