### PR TITLE
Remove redundant `get_custom_colors_dict` method

### DIFF
--- a/sugarterm.py
+++ b/sugarterm.py
@@ -522,15 +522,6 @@ class SugarTerminal(Vte.Terminal):
             self.set_colors(Gdk.RGBA(*Gdk.color_parse(fg_color).to_floats()),
                             Gdk.RGBA(*Gdk.color_parse(bg_color).to_floats()), [])
 
-    def get_custom_colors_dict(self):
-        """Returns dictionary of custom colors."""
-        return {
-            'fg_color': self._color_to_list(self.custom_fgcolor),
-            'bg_color': self._color_to_list(self.custom_bgcolor),
-            'palette': [self._color_to_list(col)
-                        for col in self.custom_palette] if self.custom_palette else None,
-        }
-
     def set_custom_colors_from_dict(self, colors_dict):
         if not isinstance(colors_dict, dict):
             return


### PR DESCRIPTION
`SugarTerminal` defined `get_custom_colors_dict` which remained unused. 

Added in df4557db0efaf477c89daae6870cd1694376ed13

Reported by @shaansubbaiah on https://github.com/sugarlabs/terminal-activity/pull/46#issuecomment-671224680