### PR TITLE
Fixes Dark Mode Button Failure 

### DIFF
--- a/sugarterm.py
+++ b/sugarterm.py
@@ -197,9 +197,8 @@ class SugarTerminal(Vte.Terminal):
         self.conf_file = os.path.join(env.get_profile_path(), 'terminalrc')
 
         if os.path.isfile(self.conf_file):
-            f = open(self.conf_file, 'r')
-            self.conf.readfp(f)
-            f.close()
+            with open(self.conf_file, 'r') as f:
+                self.conf.read_file(f)
         else:
             self.conf.add_section('terminal')
 

--- a/terminal.py
+++ b/terminal.py
@@ -611,7 +611,10 @@ class TerminalActivity(activity.Activity):
             page = self._notebook.get_nth_page(i)
 
             text = ''
-            if VTE_VERSION >= 38:
+            if VTE_VERSION >= 76:
+                # Use get_text with format for Vte version 0.76 and above
+                text = page.vt.get_text(Vte.Format.TEXT)
+            elif VTE_VERSION >= 38:
                 # in older versions of vte, get_text() makes crash
                 # the activity at random - SL #4627
                 try:
@@ -619,7 +622,7 @@ class TerminalActivity(activity.Activity):
                     # and pygobject/gobject-introspection #690041
                     text, attr_ = page.vt.get_text(is_selected, None)
                 except AttributeError:
-                    pass
+                    text = ''
 
             scrollback_lines = text.split('\n')
 
@@ -643,10 +646,10 @@ class TerminalActivity(activity.Activity):
                          'scrollback': scrollback_lines}
 
             data['tabs'].append(tab_state)
-        fd = open(file_path, 'w')
-        text = json.dumps(data)
-        fd.write(text)
-        fd.close()
+
+        with open(file_path, 'w') as fd:
+            text = json.dumps(data)
+            fd.write(text)
 
     def __clear_cb(self, button):
         vt = self._notebook.get_nth_page(self._notebook.get_current_page()).vt


### PR DESCRIPTION
### Problem  
The dark mode toggle button in the Terminal activity was non-functional on Ubuntu 24.04. Logs revealed two primary issues:  

1. **Deprecated `readfp` method:**  
   ```python
   AttributeError: 'ConfigParser' object has no attribute 'readfp'. Did you mean: 'read'?
   ```
   The `readfp` method of `ConfigParser` has been deprecated and removed in Python 3, causing `_configure_vt` to fail.

2. **`NoneType` error in `write_file`:**  
   ```python
   AttributeError: 'NoneType' object has no attribute 'split'
   ```
   When writing files, `text` was unexpectedly `None`, causing a crash when attempting to call `split()`.

---

### Solution  

- Replaced the outdated `readfp` method with `read_file` to maintain compatibility with Python 3.  
- Added a null check for `text` to ensure it is not `None` before processing.  
- Improved file handling by using `with` statements for automatic resource management.

---

### Testing  
- Tested the changes in a virtual machine running Ubuntu 24.04.  
- Installed `sucrose` and replaced `/usr/share/sugar/activities/Terminal.activity` with the updated code.  
- Rebooted the system and confirmed that the dark mode toggle now works as expected without errors.  

- Attached Video for testing:


https://github.com/user-attachments/assets/cf18e824-5fda-4e13-9cd8-fd3d03193e4e





---

This pull request resolves #51 . 





#### EDITs:
- It was this before:
```
- Installed `sucrose` and replaced `/usr/share/sugar/Terminal.activity` with the updated code.  
```
changed it for correction.
- and attached video.